### PR TITLE
Convert name to lower case before comparing to HIDs

### DIFF
--- a/lib/xbox.js
+++ b/lib/xbox.js
@@ -260,7 +260,7 @@ util.inherits(XboxController, events.EventEmitter);
 XboxController.prototype.loadController = function () {
 
   HID.devices().forEach((function (d) {
-    if (typeof d === 'object' && d.product.toLowerCase().indexOf(this.name) !== -1) {
+    if (typeof d === 'object' && d.product.toLowerCase().indexOf(this.name.toLowerCase()) !== -1) {
       this.hid = new HID.HID(d.path);
       console.log(chalk.green('notice: '), 'Xbox controller connected.');
       location = this.hid;


### PR DESCRIPTION
Downcases `this.name` before comparing to HID product strings to make sure that stuff like this doesn't fail:

``` javascript
var controller = new XboxController("Gamepad")
```

Hopefully can avoid some potential PEBKAC.
