### PR TITLE
Added windows to supported OSes, targeting node-hid v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "0.4.0",
   "os": [
     "darwin",
-    "linux"
+	 "linux",
+	 "windows"
   ],
   "repository": {
     "type": "git",
@@ -28,7 +29,7 @@
   ],
   "main": "./lib/xbox.js",
   "dependencies": {
-    "node-hid": "~>0.2.3",
+    "node-hid": "~>0.3.1",
     "chalk": "~0.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Wanted to run this on Windows, so I updated to node-hid 0.3.1 and it seems to be working fine. I don't know if it _doesn't_ work with node-hid 0.2.3; I just thought I'd try the latest version.
