### PR TITLE
Fixed platform name for Windows in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "os": [
     "darwin",
     "linux",
-    "windows"
+    "win32"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Follow-up for #15.
