### PR TITLE
Devices without product names causes error

### DIFF
--- a/lib/xbox.js
+++ b/lib/xbox.js
@@ -260,7 +260,8 @@ util.inherits(XboxController, events.EventEmitter);
 XboxController.prototype.loadController = function () {
 
   HID.devices().forEach((function (d) {
-    if (typeof d === 'object' && d.product.toLowerCase().indexOf(this.name.toLowerCase()) !== -1) {
+    var product = (typeof d === 'object' && d.product) || '';
+    if (product.toLowerCase().indexOf(this.name.toLowerCase()) !== -1) {
       this.hid = new HID.HID(d.path);
       console.log(chalk.green('notice: '), 'Xbox controller connected.');
       location = this.hid;


### PR DESCRIPTION
I was seeing errors being thrown when _some_ the results of `HID.devices()` did not have a `product` field. I've made a minor fix that supports this case.
